### PR TITLE
[WIP] Multigame Support

### DIFF
--- a/index.php
+++ b/index.php
@@ -34,7 +34,7 @@ $container['view'] = function ($container) {
     $view->getEnvironment()->addGlobal('irc_channel', $container->get('settings')['irc-channel']);
     $view->getEnvironment()->addGlobal('donation_link', $container->get('settings')['donation-link']);
     $view->getEnvironment()->addGlobal('backend_url', $container->get('settings')['backend-url']);
-    $view->getEnvironment()->addGlobal('gameshort', $container->get('settings')['gameshort']);
+    // $view->getEnvironment()->addGlobal('gameshort', $container->get('settings')['gameshort']);
     $view->getEnvironment()->addGlobal('debug', $container->get('settings')['debug']);
     $view->getEnvironment()->addGlobal('update_interval', $container->get('settings')['update-interval']);
     $view->getEnvironment()->addGlobal('registration', $container->get('settings')['registration']);

--- a/scripts/browse-list.js
+++ b/scripts/browse-list.js
@@ -13,9 +13,9 @@ function fillBrowseList() {
         browseURL = "/api/browse/" + gameshort + "/featured?site=" + page + "&count=30";
     }    
     when(getJSON(backend + '/api/users/current'), 
-           getJSON(backend + '/api/mods/' + gameshort), 
-           getJSON(backend + browseURL)).
-      done(function(currentUser, mods, browse) {
+         getJSON(backend + '/api/mods/' + gameshort), 
+         getJSON(backend + browseURL)).
+    done(function(currentUser, mods, browse) {
         app = new Vue({
             el: '#site',
             data: {
@@ -52,10 +52,10 @@ function updateBrowseList() {
     if (url == "/browse/featured") {
         browseURL = "/api/browse/" + gameshort + "/featured?site=" + page + "&count=30";
     }    
-    swhen(getJSON(backend + '/api/users/current'), 
-           getJSON(backend + '/api/mods/' + gameshort), 
-           getJSON(backend + browseURL)).
-      done(function(currentUser, mods, browse) {
+    when(getJSON(backend + '/api/users/current'), 
+         getJSON(backend + '/api/mods/' + gameshort), 
+         getJSON(backend + browseURL)).
+    done(function(currentUser, mods, browse) {
         app.$data.currentUser = currentUser.error ? null : currentUser.data;
         app.$data.mods = mods;
         app.$data.browse = browse;

--- a/scripts/create.js
+++ b/scripts/create.js
@@ -1,7 +1,7 @@
 function fillCreate() {
     when(getJSON(backend + '/api/users/current'), 
-           getJSON(backend + '/api/games/' + gameshort + '/versions')).
-      done(function(currentUser, gameversions) {
+         getJSON(backend + '/api/games/' + gameshort + '/versions')).
+    done(function(currentUser, gameversions) {
         if (currentUser.error) {
             window.location.href = "{{ path_for('accounts.login') }}";
             return;
@@ -39,8 +39,8 @@ function fillCreate() {
 
 function updateCreate() {
     when(getJSON(backend + '/api/users/current'), 
-           getJSON(backend + '/api/games/' + gameshort + '/versions')).
-      done(function(currentUser, gameversions) {
+         getJSON(backend + '/api/games/' + gameshort + '/versions')).
+    done(function(currentUser, gameversions) {
         if (currentUser.error) {
             window.location.href = "{{ path_for('accounts.login') }}";
             return;

--- a/scripts/create.js
+++ b/scripts/create.js
@@ -119,7 +119,7 @@ function onSubmitClick() {
     createMod(name, gameshort, shortDescription, license, version, gameVersion, zipFile, function(i, id, data) {
         $('#progress').removeClass('active');
         if (!data.error) {
-            window.location.href = `{{ path_for("mod.view", {"id": "${mod.id}", "name": "${mod.name}"}) }}`;
+            window.location.href = `{{ path_for("mod.view", {"gameshort": "${gameshort}", "id": "${mod.id}", "name": "${mod.name}"}) }}`;
             return;
         } else {
             $('#error-alert').removeClass('hidden');

--- a/scripts/game.js
+++ b/scripts/game.js
@@ -1,4 +1,4 @@
-function fillIndex() {
+function fillGame() {
     when(getJSON(backend + '/api/users/current'), 
          getJSON(backend + '/api/mods/' + gameshort), 
          getJSON(backend + '/api/users'),
@@ -25,12 +25,12 @@ function fillIndex() {
             }, 
             delimiters: ['${', '}'] 
         }); 
-        window.setInterval(updateIndex, update_interval);
+        window.setInterval(updateGame, update_interval);
         $.loadingBlockHide();
     });
 }
 
-function updateIndex() {
+function updateGame() {
     when(getJSON(backend + '/api/users/current'), 
          getJSON(backend + '/api/mods/' + gameshort),
          getJSON(backend + '/api/users'),

--- a/scripts/game.js
+++ b/scripts/game.js
@@ -1,9 +1,9 @@
 function fillIndex() {
     when(getJSON(backend + '/api/users/current'), 
-           getJSON(backend + '/api/mods/' + gameshort), 
-           getJSON(backend + '/api/users'), 
-           getJSON(backend + '/api/browse/' + gameshort)).
-      done(function(currentUser, mods, users, browse) {
+         getJSON(backend + '/api/mods/' + gameshort), 
+         getJSON(backend + '/api/users'),
+         getJSON(backend + '/api/browse/' + gameshort)).
+    done(function(currentUser, mods, users, browse) {
         app = new Vue({ 
             el: '#site', 
             data: { 
@@ -32,10 +32,10 @@ function fillIndex() {
 
 function updateIndex() {
     when(getJSON(backend + '/api/users/current'), 
-           getJSON(backend + '/api/mods/' + gameshort), 
-           getJSON(backend + '/api/users'), 
-           getJSON(backend + '/api/browse/' + gameshort))
-      done(function(currentUser, mods, users, browse) {
+         getJSON(backend + '/api/mods/' + gameshort),
+         getJSON(backend + '/api/users'),
+         getJSON(backend + '/api/browse/' + gameshort))
+    done(function(currentUser, mods, users, browse) {
         app.$data.currentUser = currentUser.error ? null : currentUser.data;
         app.$data.mods = mods;
         app.$data.users = users;

--- a/scripts/mod.js
+++ b/scripts/mod.js
@@ -1,19 +1,20 @@
 function fillMod() {
-    getJSON(backend + '/api/mods/' + gameshort + '/' + mod_id, function(mod) {
+    getJSON(backend + '/api/adapter/mods/' + mod_id, function(mod) {
     if (mod.error) {
         window.location.href = "{{ path_for('not-found') }}";
     }
+    var gameshort = mod.data.game_short;    
     when(getJSON(backend + '/api/users/current'), 
-           getJSON(backend + '/api/games/' + gameshort), 
-           getJSON(backend + '/api/games/' + gameshort + '/versions'),
-           getJSON(backend + '/api/users/' + mod.data.user), 
-           getJSON(backend + '/api/mods/' + gameshort + '/' + mod_id + '/stats/downloads'),
-           getJSON(backend + '/api/mods/' + gameshort + '/' + mod_id + '/stats/follower'), 
-           getJSON(backend + '/api/featured/' + gameshort),
-           hasPermission('mods-edit', true, {'gameshort': gameshort, 'modid': mod_id}),
-           hasPermission('mods-feature', true, {'gameshort': gameshort}),
-           hasPermission('mods-remove', true, {'gameshort': gameshort, 'modid': mod_id})).
-      done(function(currentUser, game, gameversions, modUser, download_stats, follower_stats, featured, editable, deletable, featureable) {
+         getJSON(backend + '/api/games/' + gameshort), 
+         getJSON(backend + '/api/games/' + gameshort + '/versions'),
+         getJSON(backend + '/api/users/' + mod.data.user),
+         getJSON(backend + '/api/mods/' + gameshort + '/' + mod_id + '/stats/downloads'),
+         getJSON(backend + '/api/mods/' + gameshort + '/' + mod_id + '/stats/follower'),
+         getJSON(backend + '/api/featured/' + gameshort),
+         hasPermission('mods-edit', true, {'gameshort': gameshort, 'modid': mod_id}),
+         hasPermission('mods-feature', true, {'gameshort': gameshort}),
+         hasPermission('mods-remove', true, {'gameshort': gameshort, 'modid': mod_id})).
+    done(function(currentUser, game, gameversions, modUser, download_stats, follower_stats, featured, editable, deletable, featureable) {
         var mod_users = {}
         mod_users[mod.data.user] = modUser.data;
         mod.data.shared_authors.forEach(function(entry) {
@@ -77,21 +78,22 @@ function fillMod() {
 }
 
 function updateMod() {
-    getJSON(backend + '/api/mods/' + gameshort + '/' + mod_id, function(mod) {
+    getJSON(backend + '/api/adapter/mods/' + mod_id, function(mod) {
     if (mod.error) {
         window.location.href = "{{ path_for('not-found') }}";
     }
+    var gameshort = mod.data.game_short;    
     when(getJSON(backend + '/api/users/current'), 
-           getJSON(backend + '/api/games/' + gameshort), 
-           getJSON(backend + '/api/games/' + gameshort + '/versions'),
-           getJSON(backend + '/api/users/' + mod.data.user), 
-           getJSON(backend + '/api/mods/' + gameshort + '/' + mod_id + '/stats/downloads'),
-           getJSON(backend + '/api/mods/' + gameshort + '/' + mod_id + '/stats/follower'), 
-           getJSON(backend + '/api/featured/' + gameshort),
-           hasPermission('mods-edit', true, {'gameshort': gameshort, 'modid': mod_id}),
-           hasPermission('mods-feature', true, {'gameshort': gameshort}),
-           hasPermission('mods-remove', true, {'gameshort': gameshort, 'modid': mod_id})).
-      done(function(currentUser, game, gameversions, modUser, download_stats, follower_stats, featured, editable, deletable, featureable) {
+         getJSON(backend + '/api/games/' + gameshort), 
+         getJSON(backend + '/api/games/' + gameshort + '/versions'),
+         getJSON(backend + '/api/users/' + mod.data.user),
+         getJSON(backend + '/api/mods/' + gameshort + '/' + mod_id + '/stats/downloads'),
+         getJSON(backend + '/api/mods/' + gameshort + '/' + mod_id + '/stats/follower'),
+         getJSON(backend + '/api/featured/' + gameshort),
+         hasPermission('mods-edit', true, {'gameshort': gameshort, 'modid': mod_id}),
+         hasPermission('mods-feature', true, {'gameshort': gameshort}),
+         hasPermission('mods-remove', true, {'gameshort': gameshort, 'modid': mod_id})).
+    done(function(currentUser, game, gameversions, modUser, download_stats, follower_stats, featured, editable, deletable, featureable) {
         var mod_users = {}
         mod_users[mod.data.user] = modUser.data;
         mod.data.shared_authors.forEach(function(entry) {

--- a/scripts/mod.js
+++ b/scripts/mod.js
@@ -1,20 +1,19 @@
 function fillMod() {
-    getJSON(backend + '/api/adapter/mods/' + mod_id, function(mod) {
+    getJSON(backend + '/api/mods/' + gameshort + '/' + mod_id, function(mod) {
     if (mod.error) {
         window.location.href = "{{ path_for('not-found') }}";
     }
-    var gameshort = mod.data.game_short;    
     when(getJSON(backend + '/api/users/current'), 
-         getJSON(backend + '/api/games/' + gameshort), 
-         getJSON(backend + '/api/games/' + gameshort + '/versions'),
-         getJSON(backend + '/api/users/' + mod.data.user),
-         getJSON(backend + '/api/mods/' + gameshort + '/' + mod_id + '/stats/downloads'),
-         getJSON(backend + '/api/mods/' + gameshort + '/' + mod_id + '/stats/follower'),
-         getJSON(backend + '/api/featured/' + gameshort),
-         hasPermission('mods-edit', true, {'gameshort': gameshort, 'modid': mod_id}),
-         hasPermission('mods-feature', true, {'gameshort': gameshort}),
-         hasPermission('mods-remove', true, {'gameshort': gameshort, 'modid': mod_id})).
-    done(function(currentUser, game, gameversions, modUser, download_stats, follower_stats, featured, editable, deletable, featureable) {
+           getJSON(backend + '/api/games/' + gameshort), 
+           getJSON(backend + '/api/games/' + gameshort + '/versions'),
+           getJSON(backend + '/api/users/' + mod.data.user), 
+           getJSON(backend + '/api/mods/' + gameshort + '/' + mod_id + '/stats/downloads'),
+           getJSON(backend + '/api/mods/' + gameshort + '/' + mod_id + '/stats/follower'), 
+           getJSON(backend + '/api/featured/' + gameshort),
+           hasPermission('mods-edit', true, {'gameshort': gameshort, 'modid': mod_id}),
+           hasPermission('mods-feature', true, {'gameshort': gameshort}),
+           hasPermission('mods-remove', true, {'gameshort': gameshort, 'modid': mod_id})).
+      done(function(currentUser, game, gameversions, modUser, download_stats, follower_stats, featured, editable, deletable, featureable) {
         var mod_users = {}
         mod_users[mod.data.user] = modUser.data;
         mod.data.shared_authors.forEach(function(entry) {
@@ -78,22 +77,21 @@ function fillMod() {
 }
 
 function updateMod() {
-    getJSON(backend + '/api/adapter/mods/' + mod_id, function(mod) {
+    getJSON(backend + '/api/mods/' + gameshort + '/' + mod_id, function(mod) {
     if (mod.error) {
         window.location.href = "{{ path_for('not-found') }}";
     }
-    var gameshort = mod.data.game_short;    
     when(getJSON(backend + '/api/users/current'), 
-         getJSON(backend + '/api/games/' + gameshort), 
-         getJSON(backend + '/api/games/' + gameshort + '/versions'),
-         getJSON(backend + '/api/users/' + mod.data.user),
-         getJSON(backend + '/api/mods/' + gameshort + '/' + mod_id + '/stats/downloads'),
-         getJSON(backend + '/api/mods/' + gameshort + '/' + mod_id + '/stats/follower'),
-         getJSON(backend + '/api/featured/' + gameshort),
-         hasPermission('mods-edit', true, {'gameshort': gameshort, 'modid': mod_id}),
-         hasPermission('mods-feature', true, {'gameshort': gameshort}),
-         hasPermission('mods-remove', true, {'gameshort': gameshort, 'modid': mod_id})).
-    done(function(currentUser, game, gameversions, modUser, download_stats, follower_stats, featured, editable, deletable, featureable) {
+           getJSON(backend + '/api/games/' + gameshort), 
+           getJSON(backend + '/api/games/' + gameshort + '/versions'),
+           getJSON(backend + '/api/users/' + mod.data.user), 
+           getJSON(backend + '/api/mods/' + gameshort + '/' + mod_id + '/stats/downloads'),
+           getJSON(backend + '/api/mods/' + gameshort + '/' + mod_id + '/stats/follower'), 
+           getJSON(backend + '/api/featured/' + gameshort),
+           hasPermission('mods-edit', true, {'gameshort': gameshort, 'modid': mod_id}),
+           hasPermission('mods-feature', true, {'gameshort': gameshort}),
+           hasPermission('mods-remove', true, {'gameshort': gameshort, 'modid': mod_id})).
+      done(function(currentUser, game, gameversions, modUser, download_stats, follower_stats, featured, editable, deletable, featureable) {
         var mod_users = {}
         mod_users[mod.data.user] = modUser.data;
         mod.data.shared_authors.forEach(function(entry) {

--- a/scripts/sdb.js
+++ b/scripts/sdb.js
@@ -148,11 +148,11 @@ function followMod(user, mod, callback) {
         window.location.href = "path_for('register')";
         return;
     }
-    getJSON(backend + '/api/mods/' + gameshort + '/' + mod.id + '/follow', callback)
+    getJSON(backend + '/api/mods/' + mod.game_short + '/' + mod.id + '/follow', callback)
 }
 
 function unfollowMod(mod, callback) {
-    getJSON(backend + '/api/mods/' + gameshort + '/' + mod.id + '/unfollow', callback);
+    getJSON(backend + '/api/mods/' + mod.game_short + '/' + mod.id + '/unfollow', callback);
 }
 
 function hasPermission(permission, pub, params, callback) {
@@ -267,7 +267,7 @@ function createMod(name, gameshort, shortDescription, license, version, gameVers
 }
 
 function updateMod(mod, version, gameVersion, notifyFollowers, isBeta, changelog, _zipFile, callback) {
-    postJSON(backend + '/api/mods/' + gameshort + '/' + mod.id + '/versions', {
+    postJSON(backend + '/api/mods/' + mod.game_short + '/' + mod.id + '/versions', {
         'version': version,
         'game-version': gameVersion,
         'notify-followers': notifyFollowers, 

--- a/scripts/update.js
+++ b/scripts/update.js
@@ -1,17 +1,17 @@
 function fillUpdate() {
-    getJSON(backend + '/api/adapter/mods/' + mod_id, function (mod) {
-    if (mod.error) {
-        window.location.href = "{{ path_for('not-found') }}";
-        return;
-    }
-    hasPermission('mods-edit', true, {'gameshort': mod.data.game_short, 'modid': mod_id}, function(canUpdate) {
+    hasPermission('mods-edit', true, {'gameshort': gameshort, 'modid': mod_id}, function(canUpdate) {
     if (!canUpdate) {
         window.location.href = "{{ path_for('not-found') }}";
         return;
     }
     when(getJSON(backend + '/api/users/current'), 
-         getJSON(backend + '/api/games/' + mod.data.game_short + '/versions')).
-    done(function(currentUser, gameversions) {        
+         getJSON(backend + '/api/games/' + gameshort + '/versions'),
+         getJSON(backend + '/api/mods/' + gameshort + '/' + mod_id)).
+      done(function(currentUser, gameversions, mod) {
+        if (mod.error) {
+            window.location.href = "{{ path_for('not-found') }}";
+            return;
+        }
         app = new Vue({
             el: '#site',
             data: {
@@ -39,29 +39,27 @@ function fillUpdate() {
         }, false);
         $('#submit').removeAttr('disabled');
         $.loadingBlockHide();
-    })})});
+    })});
 }
-    
-
 
 function updateUpdate() {
-    getJSON(backend + '/api/adapter/mods/' + mod_id, function (mod) {
-    if (mod.error) {
-        window.location.href = "{{ path_for('not-found') }}";
-        return;
-    }
-    hasPermission('mods-edit', true, {'gameshort': mod.data.game_short, 'modid': mod_id}, function(canUpdate) {
+hasPermission('mods-edit', true, {'gameshort': gameshort, 'modid': mod_id}, function(canUpdate) {
     if (!canUpdate) {
         window.location.href = "{{ path_for('not-found') }}";
         return;
     }
     when(getJSON(backend + '/api/users/current'), 
-         getJSON(backend + '/api/games/' + mod.data.game_short + '/versions')).
-    done(function(currentUser, gameversions) {
+         getJSON(backend + '/api/games/' + gameshort + '/versions'),
+         getJSON(backend + '/api/mods/' + gameshort + '/' + mod_id)).
+      done(function(currentUser, gameversions, mod) {
+        if (mod.error) {
+            window.location.href = "{{ path_for('not-found') }}";
+            return;
+        }
         app.$data.currentUser = currentUser.error ? null : currentUser.data;
         app.$data.game_versions = gameversions.data;
         app.$data.window = window;
-    })})});
+    })});
 }
 
 function onUploadClick() {

--- a/scripts/update.js
+++ b/scripts/update.js
@@ -111,7 +111,7 @@ function onSubmitClick(mod) {
     updateMod(mod, version, gameVersion, notifyFollowers, isBeta, changelog, zipFile, function(i, data) {
         $('#progress').removeClass('active');
         if (!data.error) {
-            window.location.href = `{{ path_for("mod.view", {"id": "${mod.id}", "name": "${mod.name}"}) }}`;W
+            window.location.href = `{{ path_for("mod.view", {"gameshort": "${gameshort}", "id": "${mod.id}", "name": "${mod.name}"}) }}`;W
             return;
         } else {
             $('#error-alert').removeClass('hidden');

--- a/scripts/update.js
+++ b/scripts/update.js
@@ -1,17 +1,17 @@
 function fillUpdate() {
-    hasPermission('mods-edit', true, {'gameshort': gameshort, 'modid': mod_id}, function(canUpdate) {
+    getJSON(backend + '/api/adapter/mods/' + mod_id, function (mod) {
+    if (mod.error) {
+        window.location.href = "{{ path_for('not-found') }}";
+        return;
+    }
+    hasPermission('mods-edit', true, {'gameshort': mod.data.game_short, 'modid': mod_id}, function(canUpdate) {
     if (!canUpdate) {
         window.location.href = "{{ path_for('not-found') }}";
         return;
     }
     when(getJSON(backend + '/api/users/current'), 
-         getJSON(backend + '/api/games/' + gameshort + '/versions'),
-         getJSON(backend + '/api/mods/' + gameshort + '/' + mod_id)).
-      done(function(currentUser, gameversions, mod) {
-        if (mod.error) {
-            window.location.href = "{{ path_for('not-found') }}";
-            return;
-        }
+         getJSON(backend + '/api/games/' + mod.data.game_short + '/versions')).
+    done(function(currentUser, gameversions) {        
         app = new Vue({
             el: '#site',
             data: {
@@ -39,27 +39,29 @@ function fillUpdate() {
         }, false);
         $('#submit').removeAttr('disabled');
         $.loadingBlockHide();
-    })});
+    })})});
 }
+    
+
 
 function updateUpdate() {
-hasPermission('mods-edit', true, {'gameshort': gameshort, 'modid': mod_id}, function(canUpdate) {
+    getJSON(backend + '/api/adapter/mods/' + mod_id, function (mod) {
+    if (mod.error) {
+        window.location.href = "{{ path_for('not-found') }}";
+        return;
+    }
+    hasPermission('mods-edit', true, {'gameshort': mod.data.game_short, 'modid': mod_id}, function(canUpdate) {
     if (!canUpdate) {
         window.location.href = "{{ path_for('not-found') }}";
         return;
     }
     when(getJSON(backend + '/api/users/current'), 
-         getJSON(backend + '/api/games/' + gameshort + '/versions'),
-         getJSON(backend + '/api/mods/' + gameshort + '/' + mod_id)).
-      done(function(currentUser, gameversions, mod) {
-        if (mod.error) {
-            window.location.href = "{{ path_for('not-found') }}";
-            return;
-        }
+         getJSON(backend + '/api/games/' + mod.data.game_short + '/versions')).
+    done(function(currentUser, gameversions) {
         app.$data.currentUser = currentUser.error ? null : currentUser.data;
         app.$data.game_versions = gameversions.data;
         app.$data.window = window;
-    })});
+    })})});
 }
 
 function onUploadClick() {

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -15,7 +15,7 @@ Vue.component('mod-box', {
     <div class="thumbnail">\
         <div class="ksp-update">KSP ${mod.default_version.gameversion.friendly_version}</div>\
         <div class=\"following-mod\" v-if=\"currentUser != null && currentUser.following.hasObject(mod.id)\">Following</div>\
-        <a v-bind:href="\'{{ path_for("mod.view", {"id": "<id>", "name": "<name>"}) }}\'.replace(/<id>/, mod.id).replace(/<name>/, mod.name)">\
+        <a v-bind:href="\'{{ path_for("mod.view", {"gameshort": "<gameshort>", "id": "<id>", "name": "<name>"}) }}\'.replace(/<gameshort>/, mod.game_short).replace(/<id>/, mod.id).replace(/<name>/, mod.name)">\
             <div class="header-img" v-if="mod.meta.hasOwnProperty(\'background\')" v-bind:style="\'background-image: url(//{{ backend_url }}\' + mod.meta[\'background\'].replace(/.jpg/g, \'_thumb.jpg\').replace(/.png/g, \'_thumb.png\') + \');\'"></div>\
             <div class="header-img" v-else style="background-image: url({{ path_for('images', {'filename': 'background.png'}) }});"></div>\
         </a>\

--- a/scripts/view-profile.js
+++ b/scripts/view-profile.js
@@ -4,11 +4,11 @@ function fillViewProfile() {
         window.location.href = "{{ path_for('not-found') }}";
     }
     when(getJSON(backend + '/api/users/current'),
-           hasPermission('user-edit', false, {'userid': user_id}),
-           hasPermission('admin-impersonate', true, {'userid': user_id}),
-           hasPermission('admin-confirm', true, {}),
-           hasPermission('view-users-full', false, {})).
-      done(function (currentUser, editable, canImpersonate, canConfirm, viewFull) {
+         hasPermission('user-edit', false, {'userid': user_id}),
+         hasPermission('admin-impersonate', true, {'userid': user_id}),
+         hasPermission('admin-confirm', true, {}),
+         hasPermission('view-users-full', false, {})).
+    done(function (currentUser, editable, canImpersonate, canConfirm, viewFull) {
         app = new Vue({
             el: '#site',
             data: {
@@ -42,11 +42,11 @@ function updateViewProfile() {
         window.location.href = "{{ path_for('not-found') }}";
     }
     when(getJSON(backend + '/api/users/current'),
-           hasPermission('user-edit', false, {'userid': user_id}),
-           hasPermission('admin-impersonate', true, {'userid': user_id}),
-           hasPermission('admin-confirm', true, {}),
-           hasPermission('view-users-full', false, {})).
-      done(function (currentUser, editable, canImpersonate, canConfirm, viewFull) {
+         hasPermission('user-edit', false, {'userid': user_id}),
+         hasPermission('admin-impersonate', true, {'userid': user_id}),
+         hasPermission('admin-confirm', true, {}),
+         hasPermission('view-users-full', false, {})).
+    done(function (currentUser, editable, canImpersonate, canConfirm, viewFull) {
         app.$data.currentUser = currentUser.error ? null : currentUser.data;
         app.$data.user = user.data;
         app.$data.editable = editable;

--- a/src/anonymus.php
+++ b/src/anonymus.php
@@ -1,8 +1,17 @@
 <?php
 
 $app->get('/', function($request, $response) {
-    return $this->view->render($response, 'templates/index.html');
+    // return $this->view->render($response, 'templates/index.html');
+    // TODO: Add index page
+    $gameshort = $this->get('settings')['gameshort'];
+    return $response->withRedirect("/{$gameshort}", 302);
 })->setName('index');
+
+$app->get('/{gameshort}', function($request, $response, $args) {
+    return $this->view->render($response, 'templates/game.html' [
+        'gameshort' => $args['gameshort']
+    ]);
+})->setName('game');
 
 $app->get('/privacy', function($request, $response) {
     return $this->view->render($response, 'templates/privacy.html');

--- a/src/browse.php
+++ b/src/browse.php
@@ -1,6 +1,6 @@
 <?php
 
-$app->get('/browse/new[/{page}]', function($request, $response, $args) {
+$app->get('/{gameshort}/browse/new[/{page}]', function($request, $response, $args) {
     $page = "";
     if (isset($args['page'])) {
         $page = $args['page'];
@@ -8,6 +8,7 @@ $app->get('/browse/new[/{page}]', function($request, $response, $args) {
         $page = '1';
     }
     return $this->view->render($response, 'templates/browse-list.html', [
+        'gameshort' => $args['gameshort'],
         'page' => $page,
         'url' => '/browse/new',
         'name' => 'Newest Mods', 
@@ -16,7 +17,7 @@ $app->get('/browse/new[/{page}]', function($request, $response, $args) {
     ]);
 })->setName('browse.new');
 
-$app->get('/browse/updated[/{page}]', function($request, $response, $args) {
+$app->get('/{gameshort}/browse/updated[/{page}]', function($request, $response, $args) {
     $page = "";
     if (isset($args['page'])) {
         $page = $args['page'];
@@ -24,6 +25,7 @@ $app->get('/browse/updated[/{page}]', function($request, $response, $args) {
         $page = '1';
     }
     return $this->view->render($response, 'templates/browse-list.html', [
+        'gameshort' => $args['gameshort'],
         'page' => $page,
         'url' => '/browse/updated',
         'name' => 'Recently Updated Mods', 
@@ -32,7 +34,7 @@ $app->get('/browse/updated[/{page}]', function($request, $response, $args) {
     ]);
 })->setName('browse.updated');
 
-$app->get('/browse/top[/{page}]', function($request, $response, $args) {
+$app->get('/{gameshort}/browse/top[/{page}]', function($request, $response, $args) {
     $page = "";
     if (isset($args['page'])) {
         $page = $args['page'];
@@ -40,6 +42,7 @@ $app->get('/browse/top[/{page}]', function($request, $response, $args) {
         $page = '1';
     }
     return $this->view->render($response, 'templates/browse-list.html', [
+        'gameshort' => $args['gameshort'],
         'page' => $page,
         'url' => '/browse/top',
         'name' => 'Popular Mods', 
@@ -48,7 +51,7 @@ $app->get('/browse/top[/{page}]', function($request, $response, $args) {
     ]);
 })->setName('browse.top');
 
-$app->get('/browse/featured[/{page}]', function($request, $response, $args) {
+$app->get('/{gameshort}/browse/featured[/{page}]', function($request, $response, $args) {
     $page = "";
     if (isset($args['page'])) {
         $page = $args['page'];
@@ -56,6 +59,7 @@ $app->get('/browse/featured[/{page}]', function($request, $response, $args) {
         $page = '1';
     }
     return $this->view->render($response, 'templates/browse-list.html', [
+        'gameshort' => $args['gameshort'],
         'page' => $page,
         'url' => '/browse/featured',
         'name' => 'Featured Mods', 

--- a/src/mods.php
+++ b/src/mods.php
@@ -1,12 +1,21 @@
 <?php
 
 $app->get('/mod/{id}[/{name}]', function($request, $response, $args) {
+    $backend_url = $this->get('settings')['backend-url'];
+    $json = file_get_contents("http://{$backend_url}/api/adapter/mods/{$$args['id']}");
+    $mod = json_decode($json, true);
+
+    return $response->withRedirect("{$mod['data']['game_short']}/mod/{$random_mod['data']['id']}/{$random_mod['data']['name']}", 302);
+})->setName('mod.view.adapter');
+
+$app->get('/{gameshort}/mod/{id}[/{name}]', function($request, $response, $args) {
     return $this->view->render($response, 'templates/mod.html', [
-        'modid' => $args['id']
+        'modid' => $args['id'],
+        'gameshort' => $args['gameshort']
     ]);
 })->setName('mod.view');
 
-$app->get('{gameshort}/random', function($request, $response, $args) {
+$app->get('/{gameshort}/random', function($request, $response, $args) {
     $backend_url = $this->get('settings')['backend-url'];
     // $gameshort = $this->get('settings')['gameshort'];
     // TODO(TMSP): Add an general API for this (without gameshort as an URL param)
@@ -17,7 +26,7 @@ $app->get('{gameshort}/random', function($request, $response, $args) {
     return $response->withRedirect("mod/{$random_mod['data']['id']}/{$random_mod['data']['name']}", 302);
 })->setName('mod.random');
 
-$app->get('{gameshort}/create/mod', function($request, $response, $args) {
+$app->get('/{gameshort}/create/mod', function($request, $response, $args) {
     return $this->view->render($response, 'templates/create.html', [
         'gameshort' => $args['gameshort']
     ]);

--- a/src/mods.php
+++ b/src/mods.php
@@ -6,17 +6,21 @@ $app->get('/mod/{id}[/{name}]', function($request, $response, $args) {
     ]);
 })->setName('mod.view');
 
-$app->get('/random', function($request, $response, $args) {
+$app->get('{gameshort}/random', function($request, $response, $args) {
     $backend_url = $this->get('settings')['backend-url'];
-    $gameshort = $this->get('settings')['gameshort'];
+    // $gameshort = $this->get('settings')['gameshort'];
+    // TODO(TMSP): Add an general API for this (without gameshort as an URL param)
+    $gameshort = $args['gameshort'];
     $json = file_get_contents("http://{$backend_url}/api/mods/{$gameshort}/random");
     $random_mod = json_decode($json, true);
 
     return $response->withRedirect("mod/{$random_mod['data']['id']}/{$random_mod['data']['name']}", 302);
 })->setName('mod.random');
 
-$app->get('/create/mod', function($request, $response, $args) {
-    return $this->view->render($response, 'templates/create.html');
+$app->get('{gameshort}/create/mod', function($request, $response, $args) {
+    return $this->view->render($response, 'templates/create.html', [
+        'gameshort' => $args['gameshort']
+    ]);
 })->setName('mod.create');
 
 $app->get('/update/mod/{id}[/{name}]', function($request, $response, $args) {

--- a/templates/browse-list.html
+++ b/templates/browse-list.html
@@ -1,4 +1,5 @@
 {% extends "templates/layout.html" %}
+
 {% block styles %}
 <link rel="stylesheet" type="text/css" href="{{ path_for('styles', {'filename': 'index.css'}) }}" />
 <link rel="stylesheet" type="text/css" href="{{ path_for('styles', {'filename': 'stylesheet.css'}) }}" />
@@ -6,17 +7,20 @@
 <link rel="stylesheet" type="text/css" href="{{ path_for('styles', {'filename': 'navigation.css'}) }}" />
 <link rel="stylesheet" type="text/css" href="{{ path_for('styles', {'filename': 'listing.css'}) }}" />
 {% endblock %}
+
 {% block scripts %}
 <script type="text/javascript">
-var page = {{ page }};
-var url = "{{ url }}";
-var search = {{ search }};
+    var gameshort = "{{ gameshort }}";
+    var page = {{ page }};
+    var url = "{{ url }}";
+    var search = {{ search }};
 </script>
 <script src="{{ path_for('scripts', {'filename' : 'browse-list.js'}) }}"></script>
 <script type="text/javascript">
     fillBrowseList();
 </script>
 {% endblock %}
+
 {% block title %}
 {% if search == "true" %}
 <title>Search {{ site_name }}</title>
@@ -24,6 +28,7 @@ var search = {{ search }};
 <title>{{ name }} on {{ site_name }}</title>
 {% endif %}
 {% endblock %}
+
 {% block search %}
 <form class="navbar-form navbar-right" role="search" action="/search" method="GET" style="margin-right: 5px;">
     <div class="form-group">
@@ -31,6 +36,7 @@ var search = {{ search }};
     </div>
 </form>
 {% endblock %}
+
 {% block body %}
 <div class="well">
     <div class="container">

--- a/templates/create.html
+++ b/templates/create.html
@@ -8,6 +8,7 @@
 {% block scripts %}
 <script src="{{ path_for('scripts', {'filename': 'create.js'}) }}"></script>
 <script type="text/javascript">
+    var gameshort = "{{ gameshort }}";
     fillCreate();
 </script>
 {% endblock %}

--- a/templates/game.html
+++ b/templates/game.html
@@ -7,8 +7,9 @@
 <link rel="stylesheet" type="text/css" href="{{ path_for('styles', {'filename': 'listing.css'}) }}" />
 {% endblock %}
 {% block scripts %}
-<script src="{{ path_for('scripts', {'filename' : 'index.js'}) }}"></script>
+<script src="{{ path_for('scripts', {'filename' : 'game.js'}) }}"></script>
 <script>
+    var gameshort = "{{ gameshort }}";
     fillIndex();
 </script>
 {% endblock %}

--- a/templates/game.html
+++ b/templates/game.html
@@ -10,7 +10,7 @@
 <script src="{{ path_for('scripts', {'filename' : 'game.js'}) }}"></script>
 <script>
     var gameshort = "{{ gameshort }}";
-    fillIndex();
+    fillGame();
 </script>
 {% endblock %}
 {% block body %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -37,14 +37,19 @@
     <!--[if lt IE 9]>
             <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
             <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
-        <![endif]-->
-        <script type="text/javascript">
-            var backend = "//{{ backend_url }}";
-            var gameshort = "{{ gameshort }}";
-        </script>
-    </head>
-    <body class="{% if user %}logged-in{% endif %}">
-        <div id="loading_block" style="position: fixed; width: 100%; height: 100%; background: rgb(51, 51, 51) none repeat scroll 0% 0%; left: 0px; top: 0px; z-index: 10000;"><div style="width: auto; text-align: center; margin-top: 20%;"><img src="{{ path_for('images', {'filename': 'default.svg'}) }}"><div></div></div></div>
+    <![endif]-->
+    <script type="text/javascript">
+        var backend = "//{{ backend_url }}";
+        // var gameshort = "{{ gameshort }}";
+    </script>
+</head>
+<body class="{% if user %}logged-in{% endif %}">
+    <div id="loading_block" style="position: fixed; width: 100%; height: 100%; background: rgb(51, 51, 51) none repeat scroll 0% 0%; left: 0px; top: 0px; z-index: 10000;">
+        <div style="width: auto; text-align: center; margin-top: 20%;">
+            <img src="{{ path_for('images', {'filename': 'default.svg'}) }}">
+            <div></div>
+        </div>
+    </div>
     <span id="site">
         {% block nav %}
         <nav class="navbar navbar-default navbar-fixed-top" role="navigation">

--- a/templates/mod.html
+++ b/templates/mod.html
@@ -12,6 +12,7 @@
 <script src="{{ path_for('scripts', {'filename': 'stats.js'}) }}"></script>
 <script type="text/javascript">
     var mod_id = {{ modid }};
+    var gameshort = '{{ gameshort }}';
     fillMod();
 </script>
 {% endblock %}

--- a/templates/mod.html
+++ b/templates/mod.html
@@ -231,7 +231,7 @@
             <div class="col-md-4">
                 <h2 style="margin-top: 0">Author Tools</h2>
                 <p>These are the tools you can use to manage your mod listing. You can also
-                <a v-bind:href="'{{ path_for('mod.view', {'id': '<id>', 'name': '<name>'}) }}?noedit'.replace(/<id>/, mod.id).replace(/<name>/, mod.name)">view your mod</a> as if you were not logged
+                <a v-bind:href="'{{ path_for('mod.view', {'gameshort': '<gameshort>', 'id': '<id>', 'name': '<name>'}) }}?noedit'.replace(/<gameshort>/, mod.game_short).replace(/<id>/, mod.id).replace(/<name>/, mod.name)">view your mod</a> as if you were not logged
                 in.</p>
             </div>
             <div class="col-md-8">

--- a/templates/mod.html
+++ b/templates/mod.html
@@ -57,7 +57,7 @@
             </h1>
         </div>
         <div v-bind:class="currentUser == null ? 'col-md-4' : 'col-md-2'" id="downloadWrapper">
-            <a class="btn btn-block btn-lg btn-primary piwik_download" id="download-link-primary" v-on:click="onDownloadLinkClick(currentUser)" v-bind:href="'//{{ backend_url }}/api/mods/{{ gameshort }}/{{ modid }}/download/' + mod.default_version.friendly_version">
+            <a class="btn btn-block btn-lg btn-primary piwik_download" id="download-link-primary" v-on:click="onDownloadLinkClick(currentUser)" v-bind:href="'//{{ backend_url }}/api/mods/' + mod.game_short + '/{{ modid }}/download/' + mod.default_version.friendly_version">
                 Download
             </a>
         </div>
@@ -289,7 +289,7 @@
                             <span v-if="v.changelog" v-html="marked(v.changelog)"></span>
                             <span v-else><p><em>No changelog provided</em></p></span>
                             <p v-bind:data-version="v.id">
-                                <a class="btn btn-primary piwik_download" v-bind:href="'//{{ backend_url }}/api/mods/{{ gameshort }}/{{ modid }}/download/' + v.friendly_version">
+                                <a class="btn btn-primary piwik_download" v-bind:href="'//{{ backend_url }}/api/mods/' + mod.game_short + '/{{ modid }}/download/' + v.friendly_version">
                                     <span class="fa fa-download"></span> Download
                                 </a>
                                 <template v-if="editable">

--- a/templates/update.html
+++ b/templates/update.html
@@ -63,7 +63,7 @@
                 <div class="progress-bar-striped progress-bar active" style="width: 0%"></div>
             </div>
         </button>
-        <a class="btn btn-default btn-block" style="margin: 20px auto;" v-bind:href="'{{ path_for('mod.view', {'id': '<id>', 'name': '<name>'}) }}'.replace(/<id>/, mod.id).replace(/<name>/, mod.name)">Cancel</a>
+        <a class="btn btn-default btn-block" style="margin: 20px auto;" v-bind:href="'{{ path_for('mod.view', {'gameshort': '<gameshort>', 'id': '<id>', 'name': '<name>'}) }}'.replace(/<gameshort>/, mod.game_short).replace(/<id>/, mod.id).replace(/<name>/, mod.name)">Cancel</a>
         <div class="alert alert-danger hidden" id="error-alert">
             You've missed some things! Go back and fix them first.
         </div>

--- a/templates/update.html
+++ b/templates/update.html
@@ -9,6 +9,7 @@
 <script src="{{ path_for('scripts', {'filename': 'update.js'}) }}"></script>
 <script type="text/javascript">
     var mod_id = {{ modid }};
+    var gameshort = '{{ gameshort }}';
     fillUpdate();
 </script>
 {% endblock %}


### PR DESCRIPTION
I decided to start working on this, since @V1TA5 named it as a requirement at some point, and I think we should start working on it.

My work as of now was, to replace the gameshort references to the settings file with url parameters or values fetched from the mod itself. At some points this was rather easy and smooth, at others it is a bit hacky and ugly.

There are some more or less *breaking* changes: The browse routes require the gameshort to be added in front of them now, same for the random mod and mod creation routes.

Generally, I would like to break compatibility with the current routes and add the gameshort in front of every game specific route, even mods and mod creation. The reason is, that it is much easier to have the game supplied by the URL than to add a selection to, lets say, the mod creation dialog. And I think it adds some kind of consistency.

But of course I know that we cannot simply break all mod links that are on the forums and so on. I suggest, that we still add the old mod route, but don't have any templating behind it. Instead, the PHP should query the backend (specifically the /api/adapter/mod/<modid> route), and return a redirect to the URL with the matching gameshort.

Currently this is broken at some point, but I will fix this as soon as I got time