### PR TITLE
Add missing period (member operator)

### DIFF
--- a/scripts/index.js
+++ b/scripts/index.js
@@ -34,7 +34,7 @@ function updateIndex() {
     when(getJSON(backend + '/api/users/current'), 
            getJSON(backend + '/api/mods/' + gameshort), 
            getJSON(backend + '/api/users'), 
-           getJSON(backend + '/api/browse/' + gameshort))
+           getJSON(backend + '/api/browse/' + gameshort)).
       done(function(currentUser, mods, users, browse) {
         app.$data.currentUser = currentUser.error ? null : currentUser.data;
         app.$data.mods = mods;


### PR DESCRIPTION
Just spotted this while trying to figure out something else. `fillIndex` has the form `when().done();`, but `updateIndex` is just `when() done();` without the period. I'm not intimately familiar with this idiom, but it looks like they should be the same. This pull request adds a dot to `updateIndex` before `done`.